### PR TITLE
fixed gravity bug

### DIFF
--- a/Assets/Models/track2.blend.meta
+++ b/Assets/Models/track2.blend.meta
@@ -13,6 +13,7 @@ ModelImporter:
     4300000: Cube
     7400000: Default Take
     9500000: //RootNode
+    2186277476908879412: ImportLogs
   externalObjects: {}
   materials:
     importMaterials: 1

--- a/Assets/Prefabs.meta
+++ b/Assets/Prefabs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: eb967fa736faf4484918706d9bb865f8
+guid: 6f56355c1a64fa44a82ec4e172ec9454
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -71,7 +71,10 @@ public class PlayerMovement : MonoBehaviour
             speed--;
         }
 
-        _rigidbody.velocity = transform.forward * speed;
+        Vector3 newVelocity = transform.forward * speed;
+        newVelocity.y = _rigidbody.velocity.y;
+
+        _rigidbody.velocity = newVelocity;
     }
 
 


### PR DESCRIPTION
Goal:
I created a bug with gravity when I refactored the movement code. By manipulating the velocity, gravity didn't work properly. I fixed this by making sure to NOT manipulate the velocity on the y axis, that way Unity can do its thing with gravity velocity.

How to test:
1) On the old code (Develop branch), in SampleScene, try falling off the cliff. See that you start flying!
2) Pull the new branch, see that you fall when you go off of a cliff.