### PR TITLE
Navigation and splitscreen added, tweaked view of driver

### DIFF
--- a/Assets/TopDown_Camera.cs
+++ b/Assets/TopDown_Camera.cs
@@ -1,0 +1,82 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TopDown_Camera : MonoBehaviour {
+    
+    
+    #region variables
+    [SerializeField]
+    private Transform camTarget;
+
+    [SerializeField]
+    private float height;
+
+    [SerializeField]
+    private float distance;
+
+    [SerializeField]
+    private float angle;
+
+    [SerializeField]
+    private float smoothSpeed;
+
+    [SerializeField]
+    private float zoomHeightSpeed;
+
+    [SerializeField]
+    private float zoomDistanceSpeed;
+
+    [SerializeField]
+    private float minZoom;
+
+    [SerializeField]
+    private float maxZoom;
+
+    private Vector3 refVelocity;
+    #endregion
+
+    #region unityMethods
+    // Use this for initialization
+    void Start () {
+        HandleCamera();
+	}
+	
+	// Update is called once per frame
+	void Update () {
+        zoom();
+        HandleCamera();
+	}
+    #endregion
+
+    #region helperMethod
+    void HandleCamera()
+    {
+        if (!camTarget)
+        {
+            return;
+        }
+
+        Vector3 worldPosition = (Vector3.forward * -distance) + (Vector3.up * height);
+
+        Vector3 rotatedVector = Quaternion.AngleAxis(angle, Vector3.up) * worldPosition;
+
+        Vector3 flatTargetPosition = camTarget.position;
+
+        flatTargetPosition.y = 0f;
+
+        Vector3 finalPosition = flatTargetPosition + rotatedVector;
+
+        transform.position = Vector3.SmoothDamp(transform.position, finalPosition, ref refVelocity, smoothSpeed);
+        transform.LookAt(flatTargetPosition);
+    }
+
+    void zoom()
+    {
+        height -= Input.GetAxis("Mouse ScrollWheel") * zoomHeightSpeed;
+        height = Mathf.Clamp(height, minZoom, maxZoom);
+        distance -= Input.GetAxis("Mouse ScrollWheel") * zoomDistanceSpeed;
+        distance = Mathf.Clamp(distance, minZoom, maxZoom);
+    }
+    #endregion
+}

--- a/Assets/TopDown_Camera.cs.meta
+++ b/Assets/TopDown_Camera.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b9ace05cb3e15c544bd3710af1f85aa2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2018.2.10f1
+m_EditorVersion: 2018.2.12f1


### PR DESCRIPTION
Created a script that manages the navigator's camera.

- Private, serialized fields for security
- Adjustable fields to tweak towards optimal camera distances
- Smoothing for effect

Current known bugs:
- When making a hard left or right, camera doesn't quite stay behind car
- camera flickers up and down rapidly which causes an unpleasing camera shake

-Added splitscreen
-Moved driver camera for more viewability